### PR TITLE
Cleanup constructor/options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,16 +49,16 @@ export interface LogIgnorerOptions extends StrykerOptions {
  */
 export class LogIgnorer implements Ignorer {
     public static inject = [commonTokens.options] as const
-    protected readonly options: LogIgnorerOptions
+    protected readonly options: IgnorerOptions | undefined
 
     constructor(
-        options?: LogIgnorerOptions,
+        options?: Partial<LogIgnorerOptions>,
     ) {
-        this.options = options as LogIgnorerOptions
+        this.options = options?.logignore
     }
 
     shouldIgnore(path: NodePath): string | undefined {
-        const loggerObjectNames = this.options?.logignore?.objectNames ?? [
+        const loggerObjectNames = this.options?.objectNames ?? [
             'console',
         ]
         if (

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export interface LogIgnorerOptions extends StrykerOptions {
  */
 export class LogIgnorer implements Ignorer {
     public static inject = [commonTokens.options] as const
-    protected readonly options: IgnorerOptions | undefined
+    protected readonly options?: IgnorerOptions
 
     constructor(
         options?: Partial<LogIgnorerOptions>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core'
 import { Ignorer } from '@stryker-mutator/api/ignore'
-import { Logger } from '@stryker-mutator/api/logging'
 import {
     commonTokens,
     declareFactoryPlugin,
@@ -49,13 +48,11 @@ export interface LogIgnorerOptions extends StrykerOptions {
  * LogIgnorer provides functionality to ignore log calls for provides logger object names.
  */
 export class LogIgnorer implements Ignorer {
-    public static inject = [commonTokens.logger, commonTokens.options] as const
+    public static inject = [commonTokens.options] as const
     protected readonly options: LogIgnorerOptions
 
     constructor(
-        // eslint-disable-next-line @typescript-eslint/parameter-properties
-        private readonly log?: Logger,
-        options?: StrykerOptions,
+        options?: LogIgnorerOptions,
     ) {
         this.options = options as LogIgnorerOptions
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export interface IgnorerOptions {
 }
 
 export interface LogIgnorerOptions extends StrykerOptions {
-    logignore: IgnorerOptions
+    logignore?: IgnorerOptions
 }
 
 /*


### PR DESCRIPTION
This will
- remove the unneeded logger constructor parameter
- make the logignore option optional
- extract the logignore part within the constructor to simplify access in shouldIgnore 