### PR TITLE
Use babel for NodePath type and test instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     },
     "homepage": "https://github.com/sgohlke/stryker-log-ignorer#readme",
     "devDependencies": {
+        "@babel/parser": "7.24.4",
+        "@babel/traverse": "7.24.1",
         "@types/babel__core": "7.20.5",
         "@types/node": "20.12.7",
         "@vitest/coverage-v8": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     },
     "homepage": "https://github.com/sgohlke/stryker-log-ignorer#readme",
     "devDependencies": {
+        "@types/babel__core": "7.20.5",
         "@types/node": "20.12.7",
         "@vitest/coverage-v8": "1.5.2",
         "eslint-plugin-deprecation": "2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { StrykerOptions } from '@stryker-mutator/api/core'
-import { Ignorer } from '@stryker-mutator/api/ignore'
+import { Ignorer, NodePath } from '@stryker-mutator/api/ignore'
 import {
     commonTokens,
     declareFactoryPlugin,
@@ -9,26 +9,6 @@ import {
     tokens,
 } from '@stryker-mutator/api/plugin'
 import fs from 'node:fs'
-
-/**
- * We define the necessary functions and fields for NodePath to be able to provide type safety
- * in our code.
- */
-export interface NodePath {
-    isExpressionStatement(): boolean
-    node: {
-        expression: {
-            type: string
-            callee: {
-                type: string
-                object: {
-                    type: string
-                    name: string
-                }
-            }
-        }
-    }
-}
 
 /**
  * Configuration for @sgohlke/stryker-log-ignorer

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import { StrykerOptions } from '@stryker-mutator/api/core'
 import { Ignorer, NodePath } from '@stryker-mutator/api/ignore'
 import {
-    commonTokens,
-    declareFactoryPlugin,
     Injector,
     PluginContext,
     PluginKind,
+    commonTokens,
+    declareFactoryPlugin,
     tokens,
 } from '@stryker-mutator/api/plugin'
 import fs from 'node:fs'

--- a/tests/NodePath.d.ts
+++ b/tests/NodePath.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="@stryker-mutator/api/ignore" />
+import type babel from '@babel/core'
+
+declare module '@stryker-mutator/api/ignore' {
+    export interface NodePath<T = babel.Node> extends babel.NodePath<T> {}
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,27 +1,67 @@
-import { LogIgnorer, NodePath } from '@/index'
-import { expect, test } from 'vitest'
-// import {  testInjector } from '@stryker-mutator/test-helpers';
+import { LogIgnorer, LogIgnorerOptions } from '@/index'
 
-const pathMock: NodePath = {
-    isExpressionStatement: () => true,
-    node: {
-        expression: {
-            type: 'CallExpression',
-            callee: {
-                type: 'MemberExpression',
-                object: {
-                    type: 'Identifier',
-                    name: 'console',
-                },
-            },
+import parser from '@babel/parser'
+import traverse from '@babel/traverse'
+import { NodePath } from '@stryker-mutator/api/ignore'
+import { describe, expect, test } from 'vitest'
+
+describe('LogIgnorer.shouldIgnore', () => {
+    test.each(['log', 'debug', 'info', 'warn', 'error'])(
+        'returns a truthy value when calling console.%s',
+        (method) => {
+            const logIgnorer = new LogIgnorer()
+            const path = parseExpressionStatement(`console.${method}("test")`)
+            expect(logIgnorer.shouldIgnore(path)).toBeTruthy()
         },
-    },
-}
-
-test('Test LogIgnorer function', () => {
-    // Call each log function once. Should call console.log for all log levels
-    const logIgnorer = new LogIgnorer()
-    expect(logIgnorer.shouldIgnore(pathMock)).toBe(
-        'We are not interested in testing console statements.',
     )
+
+    test('returns a truthy value when calling methods on object with name included in options', () => {
+        const options: Partial<LogIgnorerOptions> = {
+            logignore: { objectNames: ['customLogger'] },
+        }
+        const logIgnorer = new LogIgnorer(options)
+        const path = parseExpressionStatement('customLogger.log("test")')
+        expect(logIgnorer.shouldIgnore(path)).toBeTruthy()
+    })
+
+    test('returns a falsy value when calling methods on other objects than console', () => {
+        const logIgnorer = new LogIgnorer()
+        const path = parseExpressionStatement('customLogger.log("test")')
+        expect(logIgnorer.shouldIgnore(path)).toBeFalsy()
+    })
+
+    test('returns a falsy value when calling methods on other objects than configured', () => {
+        const options: Partial<LogIgnorerOptions> = {
+            logignore: { objectNames: ['customLogger'] },
+        }
+        const logIgnorer = new LogIgnorer(options)
+        const path = parseExpressionStatement('foo.log("test")')
+        expect(logIgnorer.shouldIgnore(path)).toBeFalsy()
+    })
+
+    test('returns a falsy value when passing console as an argument to a method', () => {
+        const logIgnorer = new LogIgnorer()
+        const path = parseExpressionStatement('someObject.log(console)')
+        expect(logIgnorer.shouldIgnore(path)).toBeFalsy()
+    })
 })
+
+function parseExpressionStatement(
+    sourceCode: string,
+): NodePath {
+    const ast = parser.parse(sourceCode, { sourceType: 'module' })
+
+    let statementPath: NodePath | undefined
+    traverse(ast, {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        ExpressionStatement(path) {
+            statementPath = path
+        },
+    })
+
+    if (!statementPath) {
+        throw new Error('Could not find expression statement in given code')
+    }
+
+    return statementPath
+}


### PR DESCRIPTION
This will:
- replace the custom local definition of `NodePath` by the type from `@babel/core` (via `@types/babel__core`) published under `@stryker-mutator/api/ignore` as described in https://stryker-mutator.io/docs/stryker-js/disable-mutants/#using-an-ignore-plugin
- make use of `@babel/parse` and `@babel/traverse` to build `NodePath` instances from inline source code to pass them to tests
- extend the test suite with several more positive and negative cases

I have tested the package by running `npm pack` and trying it in https://github.com/dreamit-de/graphql-prom-metrics/tree/stryker: The `console` and `logger` calls are still skipped according to the report.